### PR TITLE
Fix: incorrect header key to use for token of Azure OpenAI

### DIFF
--- a/app/api/langchain/tool/agent/agentapi.ts
+++ b/app/api/langchain/tool/agent/agentapi.ts
@@ -226,7 +226,7 @@ export class AgentApi {
 
       // const reqBody: RequestBody = await req.json();
       const isAzure = reqBody.isAzure || serverConfig.isAzure;
-      const authHeaderName = isAzure ? "api-key" : "Authorization";
+      const authHeaderName = "Authorization";
       const authToken = req.headers.get(authHeaderName) ?? "";
       const token = authToken.trim().replaceAll("Bearer ", "").trim();
 


### PR DESCRIPTION
The Azure OpenAI vendor is generally not available for actual use.

I debugged it and found that when trying to retrieve a token from the request headers, it uses the incorrect header key `api-key`, which is empty.

Before this commit:
![image](https://github.com/Hk-Gosuto/ChatGPT-Next-Web-LangChain/assets/25029451/93666d57-6eaa-49b1-be50-2ac7d88ffdd5)
After this commit:
![image](https://github.com/Hk-Gosuto/ChatGPT-Next-Web-LangChain/assets/25029451/063c09f9-6c16-407c-be3a-21ee582b71b0)
